### PR TITLE
More JSON marshaling work on FieldType and Path

### DIFF
--- a/pkg/path/fieldpath/path.go
+++ b/pkg/path/fieldpath/path.go
@@ -38,7 +38,10 @@ func (p *Path) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON returns a Path from a dotted notation string
 func (p *Path) UnmarshalJSON(b []byte) error {
-	p = FromString(string(b))
+	// remove the enclosing double quotes...
+	var s string
+	json.Unmarshal(b, &s)
+	*p = *FromString(s)
 	return nil
 }
 

--- a/pkg/path/fieldpath/path_test.go
+++ b/pkg/path/fieldpath/path_test.go
@@ -80,4 +80,9 @@ func TestJSON(t *testing.T) {
 	bytes, err := json.Marshal(p)
 	require.Nil(err)
 	require.Equal("\"Author.Name\"", string(bytes))
+
+	var np fieldpath.Path
+	err = json.Unmarshal(bytes, &np)
+	require.Nil(err)
+	require.Equal("Author.Name", np.String())
 }

--- a/pkg/types/resource/schema/field.go
+++ b/pkg/types/resource/schema/field.go
@@ -11,7 +11,10 @@
 
 package schema
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // FieldType indicates the underlying Go builtin type for a Field.
 type FieldType int
@@ -90,6 +93,22 @@ func (t FieldType) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+// MarshalJSON converts the integer representation of the field type into a
+// string.
+func (t *FieldType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
+// UnmarshalJSON converts the string representation into the enum/integer
+// representation of the field type
+func (t *FieldType) UnmarshalJSON(data []byte) error {
+	// remove the enclosing double quotes...
+	var s string
+	json.Unmarshal(data, &s)
+	*t = StringToFieldType(s)
+	return nil
 }
 
 // StringToFieldType converts a string into the associated FieldType. Uses

--- a/pkg/types/resource/schema/field_test.go
+++ b/pkg/types/resource/schema/field_test.go
@@ -1,0 +1,38 @@
+// Parts of this code modified from aws-controllers-k8s/pkg/compare
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package schema_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anydotcloud/grm/pkg/types/resource/schema"
+)
+
+func TestJSON(t *testing.T) {
+	require := require.New(t)
+
+	ft := schema.FieldTypeList
+	bytes, err := json.Marshal(&ft)
+	require.Nil(err)
+	require.Equal("\"list\"", string(bytes))
+
+	var nft schema.FieldType
+	err = json.Unmarshal(bytes, &nft)
+	require.Nil(err)
+	require.Equal(schema.FieldTypeList, nft)
+}


### PR DESCRIPTION
Adds test cases for marshaling and unmarshaling fieldpath.Path struct pointers and `pkg/types/resource/schema.FieldType` enums.